### PR TITLE
Stops address trimming in the address bar (show "http://" and "https://" in all cases)

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -342,7 +342,7 @@ pref("browser.urlbar.maxCharsForSearchSuggestions", 20);
 pref("browser.urlbar.suggest.history.onlyTyped",    false);
 
 pref("browser.urlbar.formatting.enabled", true);
-pref("browser.urlbar.trimURLs", true);
+sticky_pref("browser.urlbar.trimURLs", false);
 
 pref("browser.urlbar.oneOffSearches", true);
 


### PR DESCRIPTION
Stops the address trimming in the URL bar, improves the UI, enhances the information given in the URL bar, shows full URL by default (stops unnecessary URL shortening).