### PR TITLE
Stop implicit outbound. Part 1.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1708,7 +1708,7 @@ pref("network.http.network-changed.timeout", 5);
 
 // The maximum number of current global half open sockets allowable
 // when starting a new speculative connection.
-pref("network.http.speculative-parallel-limit", 6);
+pref("network.http.speculative-parallel-limit", 0);
 
 // Whether or not to block requests for non head js/css items (e.g. media)
 // while those elements load.
@@ -2022,7 +2022,7 @@ pref("network.dns.get-ttl", true);
 pref("network.dnsCacheExpirationGracePeriod", 60);
 
 // This preference can be used to turn off DNS prefetch.
-pref("network.dns.disablePrefetch", false);
+pref("network.dns.disablePrefetch", true);
 
 // This preference controls whether .onion hostnames are
 // rejected before being given to DNS. RFC 7686
@@ -2061,7 +2061,7 @@ pref("network.dir.format", 2);
 
 // enables the prefetch service (i.e., prefetching of <link rel="next"> and
 // <link rel="prefetch"> URLs).
-pref("network.prefetch-next", true);
+pref("network.prefetch-next", false);
 // enables the preloading (i.e., preloading of <link rel="preload"> URLs).
 pref("network.preload", true);
 


### PR DESCRIPTION
network.prefetch-next:
Link prefetching can be used by web sites to give web browsers hints about which pages are likely to be visited so that the browser can download them ahead of time, with the goal of improving performance. There is no same-origin restriction for link prefetching. According to this FAQ, "prefetching will generally cause the cookies of the prefetched site to be accessed".

network.dns.disablePrefetch:
Similar to above, this feature allows Firefox to perform DNS resolution proactively.

network.http.speculative-parallel-limit:
Disable speculative pre-connections.