### PR TITLE
Part 2: Bug 1459206 - Use FileSystemSecurity in ContentParent::RecvGe…

### DIFF
--- a/dom/ipc/ContentParent.cpp
+++ b/dom/ipc/ContentParent.cpp
@@ -5021,6 +5021,14 @@ ContentParent::RecvGetFilesRequest(const nsID& aUUID,
                                    const bool& aRecursiveFlag)
 {
   MOZ_ASSERT(!mGetFilesPendingRequests.GetWeak(aUUID));
+  
+  if (!mozilla::Preferences::GetBool("dom.filesystem.pathcheck.disabled", false)) {
+    RefPtr<FileSystemSecurity> fss = FileSystemSecurity::Get();
+    if (NS_WARN_IF(!fss ||
+                   !fss->ContentProcessHasAccessTo(ChildID(), aDirectoryPath))) {
+      return IPC_FAIL_NO_REASON(this);
+    }
+  }
 
   ErrorResult rv;
   RefPtr<GetFilesHelper> helper =


### PR DESCRIPTION
…tFilesRe…

…quest. r=ehsan, a=jcristau

--HG--
extra : rebase_source : 542dca7fe46dd965ecde4c8387685beaf20ec3de