### PR TITLE
Fix toolkit update logic to prevent update loops.

### DIFF
--- a/toolkit/mozapps/update/nsUpdateService.js
+++ b/toolkit/mozapps/update/nsUpdateService.js
@@ -2086,14 +2086,16 @@ UpdateService.prototype = {
     let lastCheckCode = AUSTLMY.CHK_NO_COMPAT_UPDATE_FOUND;
 
     updates.forEach(function(aUpdate) {
-      // Ignore updates for older versions of the application and updates for
-      // the same version of the application with the same build ID.
+      // Ignore updates for older versions of the applications and updates for
+      // the same version or build id of the application
       if (vc.compare(aUpdate.appVersion, Services.appinfo.version) < 0 ||
-          vc.compare(aUpdate.appVersion, Services.appinfo.version) == 0 &&
-          aUpdate.buildID == Services.appinfo.appBuildID) {
+         (vc.compare(aUpdate.appVersion, Services.appinfo.version) == 0 &&
+         aUpdate.buildID <= Services.appinfo.appBuildID) ||
+         (vc.compare(aUpdate.appVersion, Services.appinfo.version) == 0 &&
+         aUpdate.buildID == undefined)) {
         LOG("UpdateService:selectUpdate - skipping update because the " +
-            "update's application version is less than the current " +
-            "application version");
+            "update's application version is less than or equal to " +
+            "the current application version.");
         lastCheckCode = AUSTLMY.CHK_UPDATE_PREVIOUS_VERSION;
         return;
       }


### PR DESCRIPTION
Only consider equal appversion to be "update available" if BuildID is present AND greater than current.